### PR TITLE
Exposing Memory Information for Benchmarking and Memory Logging

### DIFF
--- a/bbhash.pyx
+++ b/bbhash.pyx
@@ -45,6 +45,7 @@ cdef extern from "BooPHF.h" namespace "boomphf":
     cdef cppclass mphf[T,U]:
         mphf(unsigned long long, vector[T], int, float, bool, bool) except +
         uint64_t lookup(uint64_t)
+        uint64_t totalBitSize()
         void save(ofstream)
         void load(ifstream)
 
@@ -81,6 +82,9 @@ cdef class PyMPHF:
             i += 1
 
         return mp_hashes
+
+    def get_mem(self):
+        return deref(self.c_mphf).totalBitSize()
 
     def save(self, str filename):
         cdef ofstream* outputter

--- a/bbhash_table.pyx
+++ b/bbhash_table.pyx
@@ -54,6 +54,12 @@ class BBHashTable(object):
 
         self.mphf_to_value[mp_hash] = value
 
+    def get_mem(self):
+        "Get memory usage."
+        return self.mphf.get_mem() + \
+               self.mphf_to_hash.nbytes + \
+               self.mphf_to_value.nbytes
+
     def get_unique_values(self, hashes, require_exist=False):
         "Retrieve unique values for item."
         values = defaultdict(int)


### PR DESCRIPTION
This pull request updates the *.pyx files to include methods that expose the memory info from the BooPHF.h library, i.e, basically the `totalBitSize()` function.